### PR TITLE
History time format

### DIFF
--- a/Views/wp-backup-to-dropbox-options.php
+++ b/Views/wp-backup-to-dropbox-options.php
@@ -203,7 +203,7 @@ try {
 			foreach ( $backup_history as $hist ) {
 				list( $backup_time, $status, $msg ) = $hist;
 				$backup_date = date( 'Y-m-d', $backup_time );
-				$backup_time_str = date( 'h:i:s', $backup_time );
+				$backup_time_str = date( 'H:i:s', $backup_time );
 				switch ( $status ) {
 					case WP_Backup::BACKUP_STATUS_STARTED:
 						echo "<span class='backup_ok'>" . sprintf( __( 'Backup started on %s at %s', 'wpbtd' ), $backup_date, $backup_time_str ) . "</span><br />";


### PR DESCRIPTION
The actual time format in which datetime is showed in history in wordpress backup to dropbox configuration page is a 12hours format without am/pm suffix.

So I suggest to change that to a 24h format.

Other alternative would be to use 12h format with am/pm suffix if you consider is better.
