### PR TITLE
Fixed wp_register_style was called incorrectly notice

### DIFF
--- a/wp-backup-to-dropbox.php
+++ b/wp-backup-to-dropbox.php
@@ -46,6 +46,9 @@ WP_Backup_Extension_Manager::construct()->init();
  * @return void
  */
 function backup_to_dropbox_admin_menu() {
+	//Register stylesheet
+	wp_register_style('wpb2d-style', plugins_url('wp-backup-to-dropbox.css', __FILE__) );
+
 	wp_enqueue_style('wpb2d-style');
 
 	$imgUrl = rtrim(WP_PLUGIN_URL, '/') . '/wordpress-backup-to-dropbox/Images/WordPressBackupToDropbox_16.png';
@@ -204,9 +207,6 @@ function backup_to_dropbox_cron_schedules($schedules) {
 	);
 	return array_merge($schedules, $new_schedules);
 }
-
-//Register stylesheet
-wp_register_style('wpb2d-style', plugins_url('wp-backup-to-dropbox.css', __FILE__) );
 
 //Delete unused options from previous versions
 delete_option('backup-to-dropbox-actions');


### PR DESCRIPTION
WordPress was throwing a notice because the stylesheet was being registered before any hooks. Since  the styles are only used on admin pages, I moved the register call into `backup_to_dropbox_admin_menu` alongside the `wp_enqueue_style` call.

Full notice message was: 

> **Notice:** wp_register_style was called **incorrectly**. Scripts and styles should not be registered or enqueued until the `wp_enqueue_scripts`, `admin_enqueue_scripts`, or `init` hooks. Please see [Debugging in WordPress](http://codex.wordpress.org/Debugging_in_WordPress) for more information. (This message was added in version 3.3.) in **/Users/[...]/wordpress/wp-includes/functions.php** on line **2758**
