### PR TITLE
Expanded the list of ignored files and added directories too

### DIFF
--- a/Classes/class-file-list.php
+++ b/Classes/class-file-list.php
@@ -20,7 +20,12 @@
  */
 class File_List {
 
-	private static $ignored_files = array('.DS_Store', 'Thumbs.db', 'desktop.ini');
+	private static $ignored_files = array(
+		'.DS_Store', 'Thumbs.db', 'desktop.ini',
+		'.git', '.gitignore', '.gitmodules',
+		'.svn',
+		'.sass-cache',
+		);
 	private $excluded_files;
 	private $excluded_dirs;
 

--- a/Views/wp-backup-to-dropbox-file-tree.php
+++ b/Views/wp-backup-to-dropbox-file-tree.php
@@ -45,6 +45,10 @@ try {
 							continue;
 						}
 
+						if ($file_list->in_ignore_list($file)) {
+							continue;
+						}
+
 						$full_path = htmlentities($_POST['dir'] . $file) . "/";
 						$file = htmlentities($file);
 						$class = $file_list->get_checkbox_class($full_path);


### PR DESCRIPTION
I added some common development dot-files to the ignored file list. Also mirrored over the ignored-file check so it catches directories too. 

Accidentally uploading my .git dir to DropBox was funny the first few times, then not so much. 
