### PR TITLE
Added all/none/inverse togglers to Excluded Files plus minor styling tweaks

### DIFF
--- a/Views/wp-backup-to-dropbox-options.php
+++ b/Views/wp-backup-to-dropbox-options.php
@@ -100,10 +100,21 @@ try {
 			multiFolder: false
 		});
 
-		$('#toggle-all').click(function (e) {
-			$('.checkbox').click();
-			e.preventDefault();
-		});
+		$('#togglers .button').click(function() {
+			switch ($(this).attr('rel')) {
+			case "all":
+				// clicking an unchecked, expanded directory triggers a collapse which is confusing
+				// skip expanded directories when checking everything (they'll auto-check themselves)
+				$('#file_tree .checkbox').not('.checked, .partial, .directory.expanded>.checkbox').click();
+				break;
+			case "none":
+				$('#file_tree .checkbox.checked').click();
+				break;
+			case "invert":
+				$('#file_tree .checkbox').not('.partial, .directory.expanded>.checkbox').click();
+				break;
+			}
+		})
 
 		$('#store_in_subfolder').click(function (e) {
 			if ($('#store_in_subfolder').is(':checked')) {
@@ -349,7 +360,11 @@ try {
 		</div>
 		<div class="loading start"><?php _e('Loading...') ?></div>
 	</div>
-	<a href="#" id="toggle-all">toggle all</a>
+	<div id="togglers"><?php _e("Exclude:", 'wpbtd'); ?>
+		<span class="button" rel="all" href="#"><?php _e("All", 'wpbtd'); ?></span>
+		<span class="button" rel="none" href="#"><?php _e("None", 'wpbtd'); ?></span>
+		<span class="button" rel="invert" href="#"><?php _e("Inverse", 'wpbtd'); ?></span>
+	</div>
 	<!--<![endif]-->
 	<p class="submit">
 		<input type="submit" id="wpb2d_save_changes" name="wpb2d_save_changes" class="button-primary" value="<?php _e('Save Changes', 'wpbtd'); ?>">

--- a/wp-backup-to-dropbox.css
+++ b/wp-backup-to-dropbox.css
@@ -11,13 +11,21 @@
 
 #file_tree {
 	margin-left: 10px;
+	padding: 5px 0 5px 10px;
 	width: 400px;
 	max-height: 200px;
+	border: 1px solid #dfdfdf;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
 	overflow-y: scroll;
 }
 
-#toggle-all {
-	margin-left: 348px;
+#togglers {
+	width: 400px;
+	margin: 10px 5px 0 10px;
+	padding: 0 0 0 7px;
+	text-align: right;
 }
 
 .bump {


### PR DESCRIPTION
Added two more buttons to your existing toggle-all, plus styling so the three options look like WP's admin secondary buttons. These are simple jQuery calls which work around some oddness related to the file-tree lib's handling of expanded directories. 

Also changed the UI label from "toggle" to "Exclude", since there seems to be some confusion about how that feature works. 
