### PR TITLE
Got test suite running with Composer autoloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.orig
 Extensions
 Tests/Out
+/vendor
+composer.lock

--- a/Tests/mock-wp-functions.php
+++ b/Tests/mock-wp-functions.php
@@ -16,8 +16,8 @@
  *          along with this program; if not, write to the Free Software
  *          Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110, USA.
  */
-$prefix = isset($prefix) ? $prefix : '';
-require_once 'Mockery/Loader.php';
+$prefix = isset($prefix) ? $prefix : dirname(__FILE__) . '/';
+require 'vendor/autoload.php';
 
 require_once($prefix . '../Dropbox/Dropbox/API.php');
 require_once($prefix . '../Dropbox/Dropbox/OAuth/Consumer/ConsumerAbstract.php');

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "phpunit/phpunit": "3.7.*",
+        "mockery/mockery": "dev-master"
+    }
+}
+


### PR DESCRIPTION
Had trouble manually getting the test dependencies in the right places, so I configured the test suite to optionally use Composer's autoloader for Mockery (and PHPUnit).

Regarding the tests, running the suite I got this result:

> Tests: 45, Assertions: 211, Errors: 10.

I might go through and patch some of the simple ones, is this result consistent with what you're seeing?
