### PR TITLE
Fixed typographical error, changed attemt to attempt in README.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,7 +188,7 @@ You can also install the zip [premium extension](http://wpb2d.com/premium) that 
 
 = 1.6.1 =
 * Added [Extendy](http://extendy.com) and improved extension installation user interface that fixes a few bugs and adds the ability to renew and buy bundles.
-* Use ABSPATH for WP root if get_home_path returns '/' that can cause the plugin the attemt to backup root.
+* Use ABSPATH for WP root if get_home_path returns '/' that can cause the plugin the attempt to backup root.
 * Improved security of DB dumps, Zip archives and the backup log. A better sha1 secret is now appended to them all and removed before upload to Dropbox.
 * Updated cURL CA Certs to the latest version from Mozilla
 * Updated dutch translations


### PR DESCRIPTION
@michaeldewildt, I've corrected a typographical error in the documentation of the [wordpress-backup-to-dropbox](https://github.com/michaeldewildt/wordpress-backup-to-dropbox) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
